### PR TITLE
Translate Japanese Markdown files to English

### DIFF
--- a/en/laravel-installation-mac.md
+++ b/en/laravel-installation-mac.md
@@ -1,0 +1,255 @@
+# Laravel Development Environment Setup for Mac (Apple Silicon)
+
+---
+
+Unlike the [Windows version](./laravel-installation-windows.md), I haven't worked on a completely new PC, but the setup method for Mac hasn't changed, so it shouldn't be an issue.
+
+Last updated: February 2023
+Environment setup information's "when" is crucial, so reading this years after the update date won't be helpful.
+
+## Update History
+- February 2023: Rewrote for Apple Silicon as I actually set up the environment on a new Mac. I used Migration Assistant, so it wasn't a completely fresh install, but since it was a change to Apple Silicon, various reinstallations were necessary.
+
+## Target Audience
+This is not for programming beginners. Laravel is not for beginners.
+
+This assumes someone who already uses Laravel and has many Laravel projects is setting up development on a different new PC.
+It assumes use on multiple PCs, such as at work and home, or Windows and Mac.
+Since professionals are the target, paid tools are included without hesitation.
+
+## Essential Knowledge Before Using Laravel
+A framework is "something to align the lower limit of knowledge." The official Laravel documentation proceeds with the assumption that you know this much.
+
+- General PC skills and above
+- Broad knowledge of the Web
+- Plain PHP. Up to the latest version. composer and PSR.
+- git / GitHub
+- Front-end knowledge. At a minimum, modern common sense like "JavaScript is now built and used" with node.js/npm is essential. The main reason beginners who have progressed from html to PHP stumble is a lack of front-end knowledge.
+- Linux knowledge. At the very least, understanding that "`php -v` is executed in the terminal."
+
+## Chrome
+https://www.google.com/intl/ja_jp/chrome/
+
+Detailed plugins will be installed automatically when synced, so I won't write them down. The same applies to subsequent apps.
+
+## GitHub Desktop
+https://desktop.github.com/
+
+## SourceTree
+https://www.sourcetreeapp.com/
+
+GitHub Desktop alone is sometimes not enough, so install SourceTree as well. On Mac, SourceTree is the main one.
+
+## VS Code
+https://code.visualstudio.com/download
+
+## PhpStorm
+https://www.jetbrains.com/ja-jp/phpstorm/download/
+
+I usually use PhpStorm for development, but I sometimes use VS Code for minor changes or make changes directly on GitHub.
+
+## Sequel Ace
+https://sequel-ace.com/
+
+For connection settings, creating one common setting for Sail is sufficient.
+
+- TCP/IP
+- Host: `localhost` or `127.0.0.1`
+- Port: 3306
+- User and Password: Those set in .env. Default sail and password are fine.
+- Database: Empty
+
+Connection is possible after starting Sail. By not specifying a database, it can be used commonly for many Laravel projects. You will need to select the database to display after connecting.
+
+If you want to share with Windows, TablePlus is also fine.
+https://tableplus.com/
+
+## Docker Desktop
+https://www.docker.com/products/docker-desktop/
+
+## iTerm2 or other terminal app
+https://iterm2.com/
+
+The standard terminal is also fine.
+
+Although not written here, customize zsh to your liking.
+
+## Xcode Command Line Tools
+It might seem unrelated to Laravel, but it's sometimes needed by Homebrew or can affect node.js/npm, so install it.
+```shell
+xcode-select --install
+```
+
+Installing Xcode from the Mac App Store shouldn't be necessary, but if problems arise later, install it.
+
+## Homebrew
+https://brew.sh/index_ja
+
+```shell
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+```
+```shell
+brew -v
+```
+
+Guidance to add to `.zprofile` will appear during installation, but ignore this if you use PhpStorm.
+```shell
+echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> /Users/***/.zprofile
+eval "$(/opt/homebrew/bin/brew shellenv)"
+```
+Add it to `.zshrc` instead of `.zprofile`. The cause is unclear, but the installation destination may change, causing PHP/composer execution from PhpStorm to fail. Adding it to `.zshrc` solves the problem.
+```shell
+echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> /Users/***/.zshrc
+eval "$(/opt/homebrew/bin/brew shellenv)"
+```
+
+On Apple Silicon, Homebrew's installation destination has changed to `/opt/homebrew/`. If you migrate from an old model using Migration Assistant, the old Homebrew will remain in `/usr/local/`, so reinstall with the new Homebrew.
+
+```shell
+cd ~/
+
+# Create Brewfile with old brew
+/usr/local/bin/brew bundle dump
+
+# Reinstall with new brew
+brew bundle
+```
+
+Commands installed with the old Homebrew can be deleted.
+
+Since the installation destination has changed, all PATHs set in various places will also change. Things that were previously recognized as `/usr/local/bin/php` as a matter of course will change, so you need to forget everything and relearn.
+
+## Install various things with Homebrew
+"Confine the entire development environment within Docker" is, realistically, an armchair theory. Such usage is too inconvenient, so keep php, composer, and npm readily available outside of Docker as well.
+
+It's easy because you just install the latest version of everything with brew.
+
+### PHP
+The brew version automatically installs extensions, so you'll rarely have problems within the scope of Laravel usage.
+```shell
+brew install php
+```
+```shell
+php -v
+```
+
+### Xdebug
+Install with pecl after PHP.
+
+```shell
+pecl install xdebug
+```
+
+To use Xdebug in on-demand mode with PhpStorm:
+https://pleiades.io/help/phpstorm/configuring-xdebug.html#on_demand_mode
+Writing tests is common in Laravel, and "step execution" is hardly ever used. So, it's fine to disable Xdebug normally and enable it only when running tests with coverage. This is the fastest way to use it.
+
+- After installing with pecl, Xdebug is automatically enabled, so edit php.ini to disable it.
+  - Check the location of php.ini with `php --ini`. For PHP 8.2, it's `/opt/homebrew/etc/php/8.2/php.ini`. Delete the line `zend_extension="xdebug.so"` or disable it with `;zend_extension="xdebug.so"`.
+- Specify the path to `xdebug.so` in PhpStorm's interpreter settings under "Debugger extension". This changes with PHP version updates, so check the display after installing with pecl. For example, for PHP 8.2, it's `/opt/homebrew/Cellar/php/8.2.0/pecl/20220829/xdebug.so`.
+- Do not copy and paste these paths as they change depending on the environment and version.
+
+### composer
+```shell
+brew install composer
+```
+```shell
+composer
+```
+
+If you plan to install `laravel/installer`. Recently, `laravel.build` is often used, so it's not strictly necessary.
+```shell
+composer global require laravel/installer
+
+laravel
+```
+
+### node.js
+```shell
+brew install node
+```
+```shell
+node -v
+npm -v
+```
+
+### Upgrade process
+```shell
+brew update
+brew upgrade
+```
+
+## Register alias for sail command
+```shell
+echo "alias sail='[ -f sail ] && sh sail || sh vendor/bin/sail'" >> ~/.zshrc
+```
+This allows you to use `sail` by itself.
+```shell
+sail version
+```
+It can be used directly in a Laravel project where composer install has been completed.
+
+## Basic Usage 1: Existing Laravel Project
+Start with a Laravel project already on GitHub.
+
+On Mac, there are no owner issues like with WSL, so cloning from SourceTree or GitHub Desktop is fine. You can save it anywhere, like `~/Sites/` or `~/Documents/`.
+Opening it with PhpStorm should prompt you to install composer and npm dependencies. You can execute them using PhpStorm's features, or in "PhpStorm's terminal" or "iTerm2, etc."
+
+```shell
+composer install
+cp .env.example .env
+php artisan key:generate
+# Edit .env if necessary
+
+npm install
+npm run build
+
+sail up -d
+
+# Always execute commands that connect to the DB, like migrate, within sail
+sail art migrate
+# Other make commands can be used outside of sail. It's slightly faster as it doesn't use Docker and can be used even before sail starts.
+php artisan make:controller TestController
+
+sail down
+```
+
+This sets up the usual development system: writing code in PhpStorm, using SourceTree/GitHub Desktop for git, and the terminal for commands.
+
+Run composer and npm scripts from PhpStorm.
+If you write sail up and down in composer.json's scripts, you can quickly start and stop sail from PhpStorm.
+```json
+        "sail:up": "./vendor/bin/sail up -d",
+        "sail:down": "./vendor/bin/sail down",
+```
+Taking it a step further, run ide-helper:models after sail up. Since a DB connection is required, running it immediately after up each time is efficient.
+```json
+        "sail:up": [
+            "./vendor/bin/sail up -d",
+            "./vendor/bin/sail art ide-helper:models -N"
+        ],
+```
+
+## Basic Usage 2: Create a New Laravel Project
+There are no changes from the official Laravel documentation.
+
+```shell
+cd ~/Sites/
+curl -s "https://laravel.build/example-app" | bash
+cd example-app
+sail up -d
+sail down
+```
+
+## Tests
+Run tests using brew's php and phpunit installed in the project with PhpStorm's features. Running with coverage also displays code coverage.
+Around November each year, to check compatibility with new PHP versions, I sometimes do things like "keep brew's PHP at 8.1 and set sail's PHP to 8.2RC for testing," so I also use `sail test`.
+
+## Points
+- Use php, composer, and npm installed with brew commonly for all Laravel projects. Since they are only used for install and update, the latest version is always fine. Create isolated environments for each project with sail. DBs, etc., are separated.
+- Since the apps and usage are the same, there's no awkwardness even when using Mac and Windows together.
+- Although WSL integrates well, it forcefully puts Linux inside Windows, so there are various things to be careful about. However, Mac, which has been UNIX-based for a long time, has no such issues.
+
+## Aside: Things beginners tend to do but shouldn't
+- MAMP, phpMyAdmin, etc., are things that beginners deceived by "wrong books and blogs written by beginners" try to install, but Laravel users never use them, so they are completely unnecessary.
+- Do not work inside Docker containers. Many beginners, even before sail appeared, have been entering Docker or Homestead (Vagrant) internals to execute commands. This is very inconvenient as you end up working in an environment different from your usual terminal. The thinking is reversed. You should use your familiar terminal outside the container to execute commands inside the container. Laravel's official sail understands this well, and `sail artisan ...` is executed outside the container. There is no need to do any work inside the container at all.

--- a/en/laravel-installation-windows.md
+++ b/en/laravel-installation-windows.md
@@ -1,0 +1,334 @@
+# Laravel Development Environment Setup on a New PC - Windows 11 Edition
+
+---
+
+This guide explains how to set up a Laravel development environment on a new Windows PC with nothing installed. I wrote this while actually working on a new PC, so it's the best approach as of now.
+
+Last updated: January 2025
+The "when" of environment setup information is crucial, so reading this years after the update date won't be helpful.
+
+## Update History
+- January 2025: Updated to PHP 8.4.
+- April 2024: Updated node.js installation method. Updated to PHP 8.3. It might be getting old as time has passed since the first edition.
+- October 2023: Changed node.js installation method to use Installation Scripts.
+- February 2023: Changed database application.
+
+## Target Audience
+This is not for programming beginners. Laravel is not for beginners.
+
+This assumes someone who already uses Laravel and has many Laravel projects is setting up development on a different new PC.
+It assumes use on multiple PCs, such as at work and home, or Windows and Mac.
+Since professionals are the target, paid tools are included without hesitation.
+
+## Essential Knowledge Before Using Laravel
+A framework is "something to align the lower limit of knowledge." The official Laravel documentation proceeds with the assumption that you know this much.
+
+- General PC skills and above
+- Broad knowledge of the Web
+- Plain PHP. Up to the latest version. composer and PSR.
+- git / GitHub
+- Front-end knowledge. At a minimum, modern common sense like "JavaScript is now built and used" with node.js/npm is essential. The main reason beginners who have progressed from html to PHP stumble is a lack of front-end knowledge.
+- Linux knowledge. At the very least, understanding that "`php -v` is executed in the terminal."
+
+## Chrome
+https://www.google.com/intl/ja_jp/chrome/
+
+Detailed plugins will be installed automatically when synced, so I won't write them down. The same applies to subsequent apps.
+
+## GitHub Desktop
+https://desktop.github.com/
+
+## SourceTree
+https://www.sourcetreeapp.com/
+
+GitHub Desktop alone is sometimes not enough, so install SourceTree as well.
+
+## VS Code
+https://code.visualstudio.com/download
+
+VS Code might ask you to install the Windows version of git. I don't use it much, but install it just in case.
+https://git-scm.com/downloads
+
+## PhpStorm
+https://www.jetbrains.com/ja-jp/phpstorm/download/
+
+I usually use PhpStorm for development, but I sometimes use VS Code for minor changes or make changes directly on GitHub.
+
+## TablePlus
+Database application
+https://tableplus.com/
+
+For connection settings, creating one common setting for Sail is sufficient.
+
+- Host: 127.0.0.1
+- Port: 3306
+- User and Password: Those set in .env. `sail` and `password`
+- Database: Empty
+
+Connection is possible after starting Sail. By not specifying a database, it can be used commonly for many Laravel projects. You will need to select the database to display after connecting.
+
+## Windows Subsystem for Linux
+Install from the Microsoft Store.
+
+At the stage where you've only installed WSL from the Store, you can display the version with `wsl --version`.
+```shell
+wsl --version
+
+WSL version: 1.0.3.0
+Kernel version: 5.15.79.1
+WSLg version: 1.0.47
+MSRDC version:
+Direct3D version:
+DXCore version:
+Windows version:
+```
+
+In Windows Terminal (PowerShell), run `wsl --install Ubuntu`.
+After downloading, decide on a new username and password for Ubuntu.
+
+```shell
+Installing, this may take a few minutes...
+Please create a default UNIX user account. The username does not need to match your Windows username.
+For more information visit: https://aka.ms/wslusers
+Enter new UNIX username:
+New password:
+Retype new password:
+passwd: password updated successfully
+Installation successful!
+```
+
+Compared to before, installing WSL has become considerably easier. If you use Laravel, you should be able to do this much as a matter of course.
+
+Subsequent commands are executed in WSL's Ubuntu.
+In Windows Terminal settings, set the existing profile to Ubuntu.
+
+## Understand File Handling in WSL
+When using WSL, you are likely to encounter permission errors. It's easy to make mistakes if you're not constantly aware of whether you're on the "Windows side" or the "WSL Ubuntu side."
+
+- Accessing WSL files from the Windows side: `\\wsl$` or `\\wsl.localhost\`
+- Accessing Windows files from the WSL side: `/mnt/c/` `/mnt/d/`
+- Within WSL: Same as normal Ubuntu `/` `/home/`
+
+### How to fix errors during composer install after git cloning with GitHub Desktop
+**(This might occur immediately after installing WSL. If it doesn't happen after a restart, you don't need to worry about it.)**
+
+Prerequisite:
+Assuming the new user created when installing WSL Ubuntu is `user`, the WSL home directory is `/home/user/`.
+Assume you created a working directory for cloning from GitHub at `/home/user/GitHub/`.
+
+WSL's `/home/user/GitHub/` is `\\wsl.localhost\Ubuntu\home\user\GitHub\` from the Windows side.
+If you clone to `\\wsl.localhost\Ubuntu\home\user\GitHub\` using GitHub Desktop on the Windows side, the file owner will be `root`, and `user` won't have write permission, causing errors during `composer install`.
+
+Confirmation. If `root` is present, the owner is `root`. If it's `user`, there's no problem, and the following is unnecessary.
+```shell
+cd ~/GitHub/
+ll
+... root root ...
+```
+
+To fix this, change the owner of the files within `/home/user/GitHub/` on the WSL side.
+```shell
+cd
+sudo chown user.user -R ./GitHub/
+```
+
+After fixing, if you clone from the WSL side next time, the owner will be `user` from the beginning, so it won't happen again.
+```shell
+cd ~/GitHub/
+git clone ...
+```
+However, I usually want to use GitHub Desktop, so it's a hassle. As long as you remember how to fix the error when it occurs, it's okay to use GitHub Desktop.
+
+## Docker Desktop
+WSL is essential for using Docker.
+https://www.docker.com/products/docker-desktop/
+
+Enable `Ubuntu` in Settings -> Resources -> WSL Integration. If this is not set, docker commands etc. cannot be used within Ubuntu.
+```
+Enable integration with additional distros:
+
+Ubuntu
+```
+
+## Install various things on the WSL Ubuntu side
+"Confine the entire development environment within Docker" is, realistically, an armchair theory. Such usage is too inconvenient, so keep php, composer, and npm readily available outside of Docker as well.
+
+This area changes with version upgrades, so don't just copy it as is.
+
+### PHP
+Since it's for artisan and composer, cli alone is fine.
+Look at Sail's Dockerfile and install the same things. Not all of them should be necessary, but they are sometimes needed during `composer install`, so install them just in case. If something is missing, add it later.
+https://github.com/laravel/sail/tree/1.x/runtimes
+
+(Details omitted so as not to have to update with every new version)
+
+```shell
+php -v
+```
+
+When an error like `ext-***` is missing during `composer install`
+```shell
+sudo apt-get install php8.4-***
+```
+
+### Use Xdebug in on-demand mode with PhpStorm
+https://pleiades.io/help/phpstorm/configuring-xdebug.html#on_demand_mode
+Writing tests is common in Laravel, and "step execution" is hardly ever used. So, it's fine to disable Xdebug normally and enable it only when running tests with coverage. This is the fastest way to use it.
+
+- Check the location of php.ini with `php --ini`. For PHP 8.4, it's `/etc/php/8.4/cli/conf.d/20-xdebug.ini`. Change it to `;zend_extension=xdebug.so` to disable it.
+- Specify the path to `xdebug.so` in PhpStorm's interpreter settings under "Debugger extension". This changes with PHP version updates. For example, for PHP 8.4, it's `/usr/lib/php/20240924/xdebug.so`.
+
+### composer
+Always copy and paste from here.
+https://getcomposer.org/download/
+
+```shell
+# Run the installation script copied from the download page.
+
+# Move composer.phar to make it usable just by typing composer.
+sudo mv composer.phar /usr/local/bin/composer
+```
+```shell
+composer -V
+```
+
+If composer is not installed, you need to use Docker for the initial installation after git clone.
+```
+docker run --rm -u "$(id -u):$(id -g)" -v "$(pwd):/var/www/html" -w var/www/html composer/composer:latest install --ignore-platform-reqs
+```
+It's easier if you can install it with PhpStorm.
+
+If you plan to install `laravel/installer`. Recently, `laravel.build` is often used, so it's not strictly necessary.
+```shell
+composer global require laravel/installer
+
+laravel
+```
+You also need to set the PATH in .bashrc to use composer commands installed globally.
+```shell
+export PATH=~/.composer/vendor/bin:$PATH
+```
+
+### node.js
+The installation method from nodesource itself changes occasionally, so always check here.
+https://github.com/nodesource/distributions
+
+This is for installing node.js 21, so be sure to check the link above and install the latest version.
+```shell
+curl -fsSL https://deb.nodesource.com/setup_21.x | sudo -E bash - &&\
+sudo apt-get install -y nodejs
+```
+```shell
+node -v
+npm -v
+```
+
+There are various methods other than installing directly into WSL, but for Laravel use, just using npm is sufficient.
+
+### Upgrade process
+```shell
+sudo apt update
+sudo apt upgrade
+
+composer selfupdate
+```
+
+## Register alias for sail command
+```shell
+echo "alias sail='[ -f sail ] && sh sail || sh vendor/bin/sail'" >> ~/.bash_aliases
+```
+This allows you to use `sail` by itself.
+```shell
+sail version
+```
+It can be used directly in a Laravel project where composer install has been completed.
+
+## Basic Usage 1: Existing Laravel Project
+Start with a Laravel project already on GitHub.
+
+First: If there is no owner issue mentioned above, you can clone from GitHub Desktop. This is the easiest. Be sure to save to the WSL side.
+
+The following is for cloning from the terminal.
+
+WSL side
+```shell
+cd ~/GitHub/
+git clone https://.../test.git
+cd test
+composer install
+cp .env.example .env
+php artisan key:generate
+# Edit .env if necessary
+
+npm install
+npm run build
+
+sail up -d
+
+# Always execute commands that connect to the DB, like migrate, within sail
+sail art migrate
+# Other make commands can be used outside of sail. It's slightly faster as it doesn't use Docker and can be used even before sail starts.
+php artisan make:controller TestController
+
+sail down
+```
+After cloning, you can immediately open it in PhpStorm and continue using PhpStorm's terminal or composer install function.
+When using composer or npm commands in PhpStorm, the interpreter selection screen will appear. At this time, configure it to use php and node within WSL.
+https://pleiades.io/help/phpstorm/configuring-remote-interpreters.html
+
+Windows side
+Add the cloned folder to GitHub Desktop.
+Add local repository -> Choose
+At this time, if you try to select the folder normally, it won't appear at first, so first display `\\wsl$\Ubuntu\home` and then navigate to the cloned folder.
+Since you are reading WSL files from the Windows side, a warning will appear when adding, but there is no problem, so select "add an exception for this directory" and proceed to add.
+The same applies when opening in PhpStorm.
+
+This sets up the usual development system: writing code in PhpStorm, using GitHub Desktop for git, and the terminal for commands.
+
+Run composer and npm scripts from PhpStorm.
+If you write sail up and down in composer.json's scripts, you can quickly start and stop sail from PhpStorm.
+```json
+        "sail:up": "./vendor/bin/sail up -d",
+        "sail:down": "./vendor/bin/sail down",
+```
+Taking it a step further, run ide-helper:models after sail up. Since a DB connection is required, running it immediately after up each time is efficient.
+```json
+        "sail:up": [
+            "./vendor/bin/sail up -d",
+            "./vendor/bin/sail art ide-helper:models -N"
+        ],
+```
+
+## Basic Usage 2: Create a New Laravel Project
+There are no changes from the official Laravel documentation.
+
+```shell
+cd ~/GitHub/
+curl -s "https://laravel.build/example-app" | bash
+cd example-app
+sail up -d
+sail down
+```
+
+The discussion about PhpStorm and GitHub Desktop is the same as above.
+
+## Tests
+Run tests using WSL's php and phpunit installed in the project with PhpStorm's features. Running with coverage also displays code coverage.
+Around November each year, to check compatibility with new PHP versions, I sometimes do things like "keep WSL's PHP at 8.1 and set sail's PHP to 8.2RC for testing," so I also use `sail test`.
+
+## Points
+- Use apps like Chrome, PhpStorm, GitHub Desktop, and VS Code on the Windows side.
+- All other file locations, execution of commands in the terminal, etc., are on the WSL side. You can place files on the Windows side, but you'll find that there's a speed difference in actual use, and the WSL side is better.
+- Use php, composer, and npm installed in WSL commonly for all Laravel projects. Since they are only used for install and update, the latest version is always fine. Create isolated environments for each project with sail. DBs, etc., are separated.
+- When the interpreter selection appears in PhpStorm, set it to use WSL. If this is not done thoroughly, it will not work properly. In a new environment, various settings are required only at the beginning, but once settled, you can use it without thinking about it.
+- In a Windows environment, as long as you can use WSL, you won't have any problems. It's a different world compared to when WSL didn't exist.
+
+## Aside: Remote Development
+If you use PhpStorm, the usage described so far is sufficient, but both PhpStorm and VS Code have remote development features. If you mainly use VS Code, it's better to use remote development.
+
+- https://pleiades.io/help/phpstorm/remote-development-starting-page.html
+- https://learn.microsoft.com/ja-jp/windows/wsl/tutorials/wsl-vscode
+
+## Aside: Things beginners tend to do but shouldn't
+- XAMPP, phpMyAdmin, etc., are things that beginners deceived by "wrong books and blogs written by beginners" try to install, but Laravel users never use them, so they are completely unnecessary.
+- Do not work inside Docker containers. Many beginners, even before sail appeared, have been entering Docker or Homestead (Vagrant) internals to execute commands. This is very inconvenient as you end up working in an environment different from your usual terminal. The thinking is reversed. You should use your familiar terminal outside the container to execute commands inside the container. Laravel's official sail understands this well, and `sail artisan ...` is executed outside the container. There is no need to do any work inside the container at all.

--- a/en/laravel-is-not-mvc.md
+++ b/en/laravel-is-not-mvc.md
@@ -1,0 +1,79 @@
+---
+title: "Laravel is Not MVC"
+emoji: "©️"
+type: "tech" # tech: Technical article / idea: Idea
+topics: ["Laravel"]
+published: true
+---
+
+# Laravel is Not MVC
+
+I wrote about this in my Zenn book, but I'm also making it an article.
+
+https://zenn.dev/pcs_engineer/books/re-laravel-1
+
+https://zenn.dev/pcs_engineer/books/re-laravel-2
+
+## Prerequisite
+This assumes an understanding of MVC (including the differences between MVC in the context of PC applications and MVC in the context of web frameworks). The point is that you can ignore MVC when using Laravel.
+
+If someone who doesn't understand MVC ignores MVC, they will only write worse code than "someone who remembers MVC incorrectly." I've seen many beginners writing code that should be in a controller directly in a Blade template using `@php ... @endphp`. People at that stage should learn MVC first.
+
+## Laravel's Model is About the Database/Eloquent
+`Illuminate\Database\Eloquent\Model` This namespace explains everything.
+https://github.com/laravel/framework/blob/10.x/src/Illuminate/Database/Eloquent/Model.php
+
+It has no responsibilities other than the database.
+
+Eloquent already has too many features, so it's best to write User and Post models declaratively without adding extra functionality. Only define standard Laravel features like relationships, accessors, and scopes. (People coming from other frameworks often make the mistake of thinking validation is the model's responsibility, but it's not.)
+
+"Business logic should be written in the model"? That's not talking about Laravel's model.
+
+## Laravel's Controller is Part of Routing
+`Illuminate\Routing\Controller`
+https://github.com/laravel/framework/blob/10.x/src/Illuminate/Routing/Controller.php
+
+It's just organizing the request handling logic into Controller classes instead of writing everything in route files.
+
+> Instead of defining all of your request handling logic as closures in your route files, you may wish to organize this behavior using "controller" classes.
+https://laravel.com/docs/10.x/controllers
+
+"You shouldn't write complex processing in controllers"? The Laravel documentation doesn't say that.
+Rather, it recommends creating single-action controllers for complex cases. All processing from routing can be written in the controller. If the same processing needs to be used elsewhere, then it can be separated into another class. (Artisan commands often reuse the same processing, so examples are written using service classes from the beginning.)
+
+Although it's named Controller, it's closer in reality to a ViewModel in MVVM. As a ViewModel, it's also the place to write business logic. If you assume it's MVC, the roles of model and controller are reversed, leading to mistakes. Laravel doesn't call it a ViewModel, so we continue to treat it as a controller.
+
+## More Important Than MVC
+Forget about MVC; thoroughly apply the "Single Responsibility Principle." Writing long processing in a controller is not what makes a Fat Controller. A Fat Controller is the result ofどんどん adding completely unrelated processing later. There are countless real-world examples of "writing Post processing that is unrelated to UserController."
+
+It's meaningless if you write this in UserController and say, "I solved the Fat Controller by separating it into PostService."
+```php:UserController
+public function postIndex(PostService $postService)
+{
+    $posts = $postService->list();
+    return view('post.index')->with(compact('posts'));
+}
+```
+It's far better to fetch directly from the Post model in PostController. With Laravel, it's easy to write tests, so this is fine at first.
+```php:PostController
+public function index()
+{
+    $posts = Post::latest()->paginate();
+    return view('post.index')->with(compact('posts'));
+}
+```
+The next step after this is "organizing using Laravel and PHP features like scopes and traits."
+
+Separating into another class is a step further down the line.
+
+In the past (from Laravel 4 to early 5), I used to create Repositories and Services, but I don't use them that way at all anymore.
+
+## Don't Arbitrarily Bring Concepts from Other Frameworks into Laravel
+Rails (7.x) explicitly states it's MVC, so it is MVC.
+https://guides.rubyonrails.org/action_controller_overview.html
+
+CakePHP (4.x) also explicitly states it's MVC.
+https://book.cakephp.org/4/en/controllers.html
+`Cake\Controller\Controller`
+
+The word "MVC" never appears in the Laravel documentation.

--- a/en/laravel-recaptcha.md
+++ b/en/laravel-recaptcha.md
@@ -1,0 +1,154 @@
+# reCAPTCHA in Laravel
+
+---
+
+If you're using Laravel's standard user registration feature, you've probably noticed an increase in automated bot registrations recently.
+Since the `/register` URL and form are fixed, registration itself is easy. If you also use the email confirmation feature, they can't proceed beyond registration, but if you want to prevent even registration, some countermeasures are necessary.
+If only a limited number of users within a company will register, simple measures like setting a common "password" that must be entered to register exist. However, for a general site where anyone can register, using reCAPTCHA is a common countermeasure.
+
+If reCAPTCHA doesn't work, consider other methods.
+
+## Versions
+- Laravel 9.x (+Jetstream/Livewire)
+- PHP 8.1
+- Google reCAPTCHA v2
+- biscolab/laravel-recaptcha 5.3
+
+## reCAPTCHA
+Uses `biscolab/laravel-recaptcha`.
+https://github.com/biscolab/laravel-recaptcha
+https://laravel-recaptcha-docs.biscolab.com/
+
+### Installation
+```
+composer require biscolab/laravel-recaptcha
+```
+
+Add to .env and .env.example.
+```
+RECAPTCHA_SITE_KEY=
+RECAPTCHA_SECRET_KEY=
+```
+
+## Get Keys from Google
+Site key and secret key.
+https://www.google.com/recaptcha/
+
+If you want to use the common "I'm not a robot" checkbox, select `reCAPTCHA v2` -> `"I'm not a robot" Checkbox`.
+Other types are fine too, so choose the one you like.
+https://developers.google.com/recaptcha/docs/versions
+
+Correctly set up your domain on the Google side. Add development environment domains like `localhost`, but delete these later.
+
+## Set Keys (for Development Environment)
+Set in .env.
+```
+RECAPTCHA_SITE_KEY=
+RECAPTCHA_SECRET_KEY=
+```
+
+## View Changes
+For Jetstream:
+Add `htmlScriptTagJsApi()` right before `</head>` in `layouts/guest.blade.php`.
+```php
+        <!-- Scripts -->
+        <script src="{{ mix('js/app.js') }}" defer></script>
+
+        {!! htmlScriptTagJsApi() !!}
+    </head>
+```
+
+Add `htmlFormSnippet()` around the registration button in `auth/register.blade.php`.
+```php
+            <div class="mt-4">
+                {!! htmlFormSnippet() !!}
+            </div>
+```
+
+If not using Jetstream, adapt to your specific environment.
+
+## Add Validation
+For Jetstream, in `app/Actions/Fortify/CreateNewUser.php`.
+```php
+        Validator::make($input, [
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
+            'password' => $this->passwordRules(),
+            recaptchaFieldName() => recaptchaRuleName(),
+            'terms' => Jetstream::hasTermsAndPrivacyPolicyFeature() ? ['required', 'accepted'] : '',
+        ])->validate();
+```
+
+Both `recaptchaFieldName()` and `recaptchaRuleName()` are helpers provided by `biscolab/laravel-recaptcha`.
+You can also use `'g-recaptcha-response' => 'recaptcha',` instead of the helpers.
+
+## Temporary Confirmation in Development Environment
+If you set the domain on the Google side, it will work even in the development environment, so manually check that registration succeeds or fails depending on reCAPTCHA.
+
+## Disable reCAPTCHA in Development Environment (v2)
+Once thoroughly confirmed, it's no longer needed in the development environment.
+Test keys are available here, so setting them in .env will allow validation to pass regardless of reCAPTCHA.
+```
+Site key: 6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI
+Secret key: 6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe
+```
+https://developers.google.com/recaptcha/docs/faq#id-like-to-run-automated-tests-with-recaptcha.-what-should-i-do
+
+```
+RECAPTCHA_SITE_KEY=6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI
+RECAPTCHA_SECRET_KEY=6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe
+#For production
+#RECAPTCHA_SITE_KEY=
+#RECAPTCHA_SECRET_KEY=
+```
+
+Remove domains like localhost from the Google side.
+
+## Add Test Keys for phpunit as well
+For testing in CI.
+phpunit.xml
+```xml
+        <!--Test Keys-->
+        <env name="RECAPTCHA_SITE_KEY" value="6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI"/>
+        <env name="RECAPTCHA_SECRET_KEY" value="6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe"/>
+```
+
+This will also pass the tests provided by Jetstream.
+
+## Production Environment Settings
+Set the production keys in .env.
+
+Confirm it works, and you're done.
+
+## Using reCAPTCHA v2 invisible
+Publish the config file:
+```
+php artisan vendor:publish --provider="Biscolab\ReCaptcha\ReCaptchaServiceProvider"
+```
+Change config/recaptcha.php to use `invisible`.
+```php
+'version'                      => 'invisible',
+```
+
+`htmlScriptTagJsApi()` is the same as for v2.
+
+For `auth/register.blade.php`, add an id to the form:
+```php
+<form id="{{ getFormId() }}">
+```
+And add data-sitekey etc. to the button (for Jetstream):
+```php
+<x-jet-button class="ml-4 g-recaptcha"
+              data-callback="biscolabLaravelReCaptcha"
+              data-sitekey="{{ config('recaptcha.api_site_key') }}">
+    {{ __('Register') }}
+</x-jet-button>
+```
+Using `htmlFormButton()` with Jetstream results in many classes, so adding data-sitekey yourself seems better.
+
+https://laravel-recaptcha-docs.biscolab.com/docs/how-to-use-v2#recaptcha-v2-invisible
+
+## Using reCAPTCHA v3
+`biscolab/laravel-recaptcha` defaults to v2, so publish the config file and change it to use v3.
+Then refer to the documentation.
+https://laravel-recaptcha-docs.biscolab.com/docs/how-to-use-v3

--- a/en/laravel-taboo.md
+++ b/en/laravel-taboo.md
@@ -1,0 +1,42 @@
+# Laravel Taboos
+
+---
+
+Examples of Laravel projects I wouldn't get involved with even if requested.
+
+## Do Not Write jQuery Directly in Views
+
+Loading an old version of jQuery and writing JS code directly in the view. Even when using Laravel, there are surprisingly many cases like this. If you join such a project midway, investigating what is happening where is incredibly difficult. Even if you take it over, fixing this is impossible, so it's unacceptable.
+
+```html
+<html>
+<head>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
+</head>
+<body>
+
+<button id="btn">Button</button>
+<script>
+    $(function () {
+        $("#btn").click(function () {
+            alert("hello");
+        });
+    });
+</script>
+
+</body>
+</html>
+```
+
+## Do Not Bring Other Framework's Practices into Laravel
+I've seen various things, but this pattern is the one where Laravel is most often used incorrectly.
+
+People make huge mistakes because they don't relearn how to use Laravel and instead forcibly apply the practices of other frameworks to Laravel.
+
+Writing jQuery directly in the view, as mentioned above, is ultimately a derivative of this.
+
+## Do Not Use Versions Whose Support Has Ended
+It is essential to use supported versions of Laravel, PHP, and everything else. If you inherit a project, the first task is to upgrade the versions.
+
+- Laravel: https://laravelversions.com/
+- PHP: https://www.php.net/supported-versions.php

--- a/en/laravel-unless.md
+++ b/en/laravel-unless.md
@@ -1,0 +1,132 @@
+# PHP Lacks `unless`, so Laravel's Similar Features are Subtly Useful
+
+---
+
+Negation with `!` like in `if(! $test)` is commonly used even within Laravel's internal code, but personally, I prefer to avoid it. It's a usage that relies on PHP's loose type coercion. Within Laravel, it's just an inversion with `!`, so in terms of actual behavior, being particular about it is meaningless.
+
+## Versions
+- Laravel 9.x
+- PHP 8.1
+
+## Blade's @unless
+```php
+@unless (Auth::check())
+    You are not signed in.
+@endunless
+```
+
+https://laravel.com/docs/9.x/blade#if-statements
+
+## Collection's doesntContain()
+```php
+$collection = collect(['name' => 'Desk', 'price' => 100]);
+
+if($collection->doesntContain('Table')) {
+
+}
+```
+
+https://laravel.com/docs/9.x/collections#method-doesntcontain
+
+Internally, Laravel just inverts `contains()`.
+```php
+    public function doesntContain($key, $operator = null, $value = null)
+    {
+        return ! $this->contains(...func_get_args());
+    }
+```
+
+## Eloquent / QueryBuilder's doesntExist()
+```php
+if (DB::table('orders')->where('finalized', 1)->doesntExist()) {
+    // ...
+}
+```
+
+https://laravel.com/docs/9.x/queries#determining-if-records-exist
+
+## Conditionable Trait's when()/unless()
+Since it's a trait, it can be used in various places, but it's often used with Collections and QueryBuilders.
+```php
+$collection = collect([1, 2, 3]);
+
+$collection->unless(true, function ($collection) {
+    return $collection->push(4); // This will not be executed
+});
+
+$collection->unless(false, function ($collection) {
+    return $collection->push(5); // This will be executed
+});
+
+$collection->all();
+
+// [1, 2, 3, 5]
+// The result is only 5, not 4.
+```
+
+`when()` can be used to filter only when a condition is specified in a search form.
+
+```php
+$role = $request->input('role');
+
+$users = DB::table('users')
+                ->when($role, function ($query, $role) {
+                    $query->where('role_id', $role);
+                })
+                ->get();
+```
+
+I don't want to write `when($role` like this.
+```php
+->when(filled($role), function ($query, $b) use($role)) {
+```
+Check with `filled()` as the opposite of `empty()`. Since `$role` is not passed directly, pass it separately using `use($role)`.
+```php
+->unless(blank($role),
+```
+For `unless`, use `blank()` or `empty()`.
+
+https://github.com/laravel/framework/blob/9.x/src/Illuminate/Conditionable/Traits/Conditionable.php
+https://laravel.com/docs/9.x/collections#method-unless
+https://laravel.com/docs/9.x/queries#conditional-clauses
+
+Additionally, in this situation, the presence or absence of `return` makes no difference.
+```php
+->when(filled($role), function ($query) use($role) {
+    return $query->where('role_id', $role);
+})
+```
+So, you can also write it with an arrow function.
+```php
+->when(filled($role), fn ($query) => $query->where('role_id', $role))
+```
+
+## abort_unless()
+```php
+abort_unless(Auth::user()->isAdmin(), 403);
+```
+```php
+abort_if(! Auth::user()->isAdmin(), 403);
+```
+The documentation also seems to imply that `unless` is preferable to inversion with `!`.
+
+https://laravel.com/docs/9.x/helpers#method-abort-unless
+
+```php
+    function abort_unless($boolean, $code, $message = '', array $headers = [])
+    {
+        if (! $boolean) {
+            abort($code, $message, $headers);
+        }
+    }
+```
+Here too, Laravel uses `!` internally, but "framework code and userland code are different," so I still want to avoid `!` in userland code.
+
+## missing
+The opposite of `has` is `missing`. Used in tests like `assertDatabaseMissing()` and `assertJsonMissing()`, and Request's `$request->missing()`.
+
+```php
+if ($request->missing('name')) {
+    //
+}
+```

--- a/en/laravel-vite-plugin.md
+++ b/en/laravel-vite-plugin.md
@@ -1,0 +1,164 @@
+# Migrating from Laravel Mix to laravel-vite-plugin
+
+---
+
+## Introduction
+laravel-vite-plugin
+https://github.com/laravel/vite-plugin
+Migration documentation is here:
+https://github.com/laravel/vite-plugin/blob/main/UPGRADE.md
+Official documentation:
+https://laravel.com/docs/vite
+Vite:
+https://vitejs.dev/
+
+Vite will replace Laravel Mix in the future, but it doesn't replace all features, so there's no need to forcibly change existing projects that use Laravel Mix.
+Vite is sufficient for typical Laravel usage as intended by the framework.
+There are likely still things that only Mix can do, and if you're not even using Mix, this doesn't concern you.
+
+## Versions
+- Laravel 9.19.0 or later
+- Vite 2.9
+- laravel-vite-plugin 0.2.3
+
+## Target
+A very standard Laravel project using the official Laravel starter kits around Laravel 8.x/9.x.
+
+## Inside laravel-vite-plugin
+Laravel Mix was built with a lot of features to make webpack easier to use, but vite-plugin is simpler.
+It's just a "Vite plugin" and mainly provides "automatic configuration for Laravel." It's only one file.
+https://github.com/laravel/vite-plugin/blob/main/src/index.ts
+
+While Laravel Mix was often used outside of Laravel, there's no reason to use laravel-vite-plugin; you can just use Vite directly.
+
+## Migration Steps
+
+### Install Vite
+Although not in the migration documentation as of version 0.2.3, `autoprefixer` is also required. This will be unnecessary if it's added to package.json in future versions.
+```
+npm install --save-dev vite laravel-vite-plugin autoprefixer
+```
+
+### Create vite.config.js file
+The plugin simply handles the various settings configured in this file.
+
+```js
+import { defineConfig } from 'vite';
+import laravel from 'laravel-vite-plugin';
+// import react from '@vitejs/plugin-react';
+// import vue from '@vitejs/plugin-vue';
+
+export default defineConfig({
+    plugins: [
+        laravel([
+            'resources/css/app.css',
+            'resources/js/app.js',
+        ]),
+        // react(),
+        // vue({
+        //     template: {
+        //         transformAssetUrls: {
+        //             base: null,
+        //             includeAbsolute: false,
+        //         },
+        //     },
+        // }),
+    ],
+});
+```
+
+### Change npm scripts
+```json
+"scripts": {
+    "dev": "vite",
+    "build": "vite build"
+}
+```
+
+### Change require() to import
+Refer to this:
+https://github.com/laravel/laravel/pull/5895/files
+
+No need to change `require()` in `tailwind.config.js`.
+
+### If using Inertia or environment variables starting with MIX_
+Refer to the migration documentation for changes.
+
+### For SPAs, load CSS from JS
+resources/js/app.js
+```diff
+  import './bootstrap';
++ import '../css/app.css';
+```
+
+### Change mix() to @vite()
+```diff
+- <link rel="stylesheet" href="{{ mix('css/app.css') }}">
+- <script src="{{ mix('js/app.js') }}" defer></script>
++ @vite(['resources/css/app.css', 'resources/js/app.js'])
+```
+
+`@vite()` was added in Laravel 9.19.
+
+### If using React or Vue
+Refer to the migration documentation for changes.
+
+### Remove Laravel Mix
+```
+npm remove laravel-mix
+```
+`webpack.mix.js` is also no longer needed.
+```
+rm webpack.mix.js
+```
+
+If any built JS/CSS files or other unnecessary files remain in the `public` directory, delete them.
+
+### postcss.config.js is needed for Tailwind
+```
+npx tailwindcss init -p
+```
+`postcss-import` should not be necessary, but if it is, specify it like this:
+```js
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+    'postcss-import': {},
+  },
+}
+```
+If you are using `@import` in `app.css`, `postcss-import` is necessary.
+If you are using `@tailwind`, it is not necessary.
+
+### Adding to .gitignore depends on your policy
+Add if you build during deployment.
+```
+/public/build
+```
+Do not add if you include built JS/CSS files in the repository.
+
+### Commands
+For `watch` in Laravel Mix:
+```
+npm run dev
+```
+
+For `prod`:
+```
+npm run build
+```
+
+Built files are created in `public/build/`.
+
+## Missing Features
+Things that cannot be done with Vite + laravel-vite-plugin can be added with other Vite plugins (or Rollup plugins), so once more information is available, Mix will likely be completely replaceable.
+
+For example, these could be used as alternatives to `mix.copy()`:
+
+- https://github.com/sapphi-red/vite-plugin-static-copy
+- https://github.com/mistjs/vite-plugin-copy-files
+
+Vite's standard way is to copy from the `public` directory, but this is difficult to use with Laravel, so it is disabled by `laravel-vite-plugin`.
+
+- https://vitejs.dev/guide/assets.html#the-public-directory

--- a/en/laravel11-application-builder.md
+++ b/en/laravel11-application-builder.md
@@ -1,0 +1,219 @@
+# Laravel 11: Undocumented Ways to Use bootstrap/app.php
+
+---
+
+This is a summary for a frequently asked question on overseas Q&A sites.
+
+It's rarely seen in Japan. The Laravel community in Japan is polarized between **beginners who ask questions about what's already in the documentation** and **veterans who don't need to ask questions**. There's a lack of people in the intermediate stage who are trying to do slightly more complex things not covered in the documentation.
+
+## Version
+- Laravel 11
+- PHP 8.3
+
+Always check the version when discussing Laravel. Features might not exist in older versions, or their usage might change in future versions.
+
+## Basic Flow Before bootstrap/app.php
+The entry point for Laravel is:
+For HTTP: `public/index.php`
+```php
+// Bootstrap Laravel and handle the request...
+(require_once __DIR__.'/../bootstrap/app.php')
+    ->handleRequest(Request::capture());
+```
+
+For Console: `artisan`
+```php
+// Bootstrap Laravel and handle the command...
+$status = (require_once __DIR__.'/bootstrap/app.php')
+    ->handleCommand(new ArgvInput);
+```
+
+`bootstrap/app.php`, which is loaded by both, has become a crucial file in Laravel 11.
+
+## Normal Usage of bootstrap/app.php
+Actually, the normal usage isn't well documented. It's mostly in the Laravel 11 release notes and scattered throughout the documentation for specific features.
+https://laravel.com/docs/11.x/releases
+
+Important prerequisite: **`bootstrap/app.php` is before Laravel boots.** Features that are readily available after booting cannot be used here.
+If you don't understand this, you'll try to use `config()` etc. in `bootstrap/app.php` and get errors.
+
+(Technically, since `basePath` is set initially, `base_path()` can be used. However, it's likely unused to avoid the misconception that other helpers are also available.)
+
+## The Code to Investigate is ApplicationBuilder
+What `Application::configure()` in `bootstrap/app.php` returns is:
+```php
+use Illuminate\Foundation\Application;
+
+return Application::configure(basePath: dirname(__DIR__))
+```
+`Illuminate\Foundation\Configuration\ApplicationBuilder`
+```php
+    public static function configure(?string $basePath = null)
+    {
+        $basePath = match (true) {
+            is_string($basePath) => $basePath,
+            default => static::inferBasePath(),
+        };
+
+        return (new Configuration\ApplicationBuilder(new static($basePath)))
+            ->withKernels()
+            ->withEvents()
+            ->withCommands()
+            ->withProviders();
+    }
+```
+https://github.com/laravel/framework/blob/11.x/src/Illuminate/Foundation/Application.php
+
+`bootstrap/app.php` is mostly `ApplicationBuilder`, so you just need to examine this.
+https://github.com/laravel/framework/blob/11.x/src/Illuminate/Foundation/Configuration/ApplicationBuilder.php
+
+This was all introductory.
+
+## To Interject Processing After Booting, Use booted()
+Although `bootstrap/app.php` is before Laravel boots, only `booted()` is after booting. Here, all Laravel features can be used.
+The answer to most questions like "I want to do something special in bootstrap/app.php" is this.
+
+```php
+use Illuminate\Foundation\Application;
+use Illuminate\Foundation\Configuration\Exceptions;
+use Illuminate\Foundation\Configuration\Middleware;
+
+return Application::configure(basePath: dirname(__DIR__))
+    ->withRouting(
+        web: __DIR__.'/../routes/web.php',
+        commands: __DIR__.'/../routes/console.php',
+        health: '/up',
+    )
+    ->withMiddleware(function (Middleware $middleware) {
+        //
+    })
+    ->withExceptions(function (Exceptions $exceptions) {
+        //
+    })
+    ->booted(function (Application $app) {
+        info($app->version());
+        info(config('app.name'));
+    })->create();
+```
+
+It's hard to see with a simple example, but you can do anything at this `booted` stage.
+"Special things" include "ignoring all middleware set with `withMiddleware` and reconfiguring them."
+I don't know why anyone would want to do that, but such questions have actually existed.
+
+Since it's not something you'd normally do, I won't explain the details.
+
+```php
+    ->booted(function (Application $app) {
+        $kernel = $app->make(Kernel::class);
+
+        $middleware = (new Middleware)
+            ->redirectGuestsTo(fn () => route('login'));
+
+        // $middleware->...
+
+        $kernel->setGlobalMiddleware($middleware->getGlobalMiddleware());
+        $kernel->setMiddlewareGroups($middleware->getMiddlewareGroups());
+        $kernel->setMiddlewareAliases($middleware->getMiddlewareAliases());
+
+        if ($priorities = $middleware->getMiddlewarePriority()) {
+            $kernel->setMiddlewarePriority($priorities);
+        }
+
+        $app->instance(Kernel::class, $kernel);
+    })
+```
+
+Only those who are intimately familiar with Laravel's internals would use this, so it can't be documented.
+
+## There are also registered() and booting()
+Laravel's boot process follows this order. `bootstrap/app.php` has corresponding methods, so choose based on when you want to interject processing. There are things you can and cannot do at each timing.
+
+- Execute `register()` of all ServiceProviders
+- app's `registered()`
+- app's `booting()`
+- Execute `boot()` of all ServiceProviders
+- app's `booted()`
+
+The middleware example is easier to understand with `registered()`, but:
+```php
+    ->registered(function (Application $app) {
+        $app->afterResolving(Kernel::class, function ($kernel) {
+            $middleware = (new Middleware)
+                ->redirectGuestsTo(fn () => route('login'));
+
+            // $middleware->...
+
+            $kernel->setGlobalMiddleware($middleware->getGlobalMiddleware());
+            $kernel->setMiddlewareGroups($middleware->getMiddlewareGroups());
+            $kernel->setMiddlewareAliases($middleware->getMiddlewareAliases());
+
+            if ($priorities = $middleware->getMiddlewarePriority()) {
+                $kernel->setMiddlewarePriority($priorities);
+            }
+        });
+    })
+```
+
+Realistically, it's better to write long code in a ServiceProvider than in `bootstrap/app.php`.
+If you want to "execute after all ServiceProviders," using `booted()` has its purpose, but it's for very specific uses.
+
+Writing it in AppServiceProvider is the same.
+```php
+class AppServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        info('1. AppServiceProvider register');
+
+        $this->booting(function () {
+            info('4. AppServiceProvider booting');
+        });
+
+        $this->booted(function () {
+            info('5. AppServiceProvider booted');
+        });
+
+        $this->app->registered(function () {
+            info('2. app registered');
+        });
+
+        $this->app->booting(function () {
+            info('3. app booting');
+        });
+
+        $this->app->booted(function () {
+            info('6. AppServiceProvider@register app booted');
+        });
+    }
+
+    public function boot(): void
+    {
+        $this->app->booted(function () {
+            info('7. AppServiceProvider@boot app booted');
+        });
+    }
+}
+```
+
+## withBindings() and withSingletons()
+You can just use ServiceProviders, so there's likely little need to write these in `bootstrap/app.php`.
+
+## withMiddleware()
+Although scattered throughout the documentation, it should be mostly explained.
+https://laravel.com/docs/11.x/middleware
+
+If you want to know the details, you have no choice but to look at the code.
+https://github.com/laravel/framework/blob/11.x/src/Illuminate/Foundation/Configuration/Middleware.php
+
+## withExceptions()
+It's explained in the documentation, but some parts might still be unclear.
+https://laravel.com/docs/11.x/errors
+
+Again, you have no choice but to look at the code.
+https://github.com/laravel/framework/blob/11.x/src/Illuminate/Foundation/Configuration/Exceptions.php
+https://github.com/laravel/framework/blob/11.x/src/Illuminate/Foundation/Exceptions/Handler.php
+
+- To change the response for each type of exception, use `$exceptions->render()`
+- To change the processing just before returning the final response, use `$exceptions->respond()`
+
+Knowing this much should be sufficient for commonly seen questions.

--- a/en/livewire-pagination.md
+++ b/en/livewire-pagination.md
@@ -1,0 +1,134 @@
+# Auto-scroll After Page Change in Laravel/Livewire Pagination
+
+---
+
+## Versions
+- Laravel 9.x (+Jetstream 2.x)
+- Livewire 2.x
+- Alpine.js 3.x
+- PHP 8.1
+
+## Livewire Pagination
+https://laravel-livewire.com/docs/2.x/pagination
+
+```php
+use Livewire\WithPagination;
+
+class ShowPosts extends Component
+{
+    use WithPagination;
+
+    public function render()
+    {
+        return view('livewire.show-posts', [
+            'posts' => Post::paginate(10),
+        ]);
+    }
+}
+```
+```php
+<div>
+    @foreach ($posts as $post)
+        ...
+    @endforeach
+
+    {{ $posts->links() }}
+</div>
+```
+
+It can be used almost the same way as Laravel's pagination, and the page display switches without a full reload.
+
+This alone is simple, but when actually using it, "if you change pages at the bottom of a long page, the display just changes as is, which is slightly inconvenient." You'll want to scroll to the top.
+
+## Scrolling with dispatchBrowserEvent() and Alpine.js
+First, the PHP side.
+
+You can dispatch an event from the PHP side to JS using `dispatchBrowserEvent()`.
+https://laravel-livewire.com/docs/2.x/events#browser
+
+```php
+use Livewire\WithPagination;
+
+class ShowPosts extends Component
+{
+    use WithPagination;
+
+    public function updatedPage($page)
+    {
+        $this->dispatchBrowserEvent('page-updated');
+    }
+
+    public function render()
+    {
+        return view('livewire.show-posts', [
+            'posts' => Post::paginate(10),
+        ]);
+    }
+}
+```
+
+When the page changes in `updatedPage()`, an event is dispatched. (Since `updatedPage()` is used when `page` is used like `?page=2`, adjustments are needed if using multiple paginations.)
+
+Next, the view side.
+
+Events from `dispatchBrowserEvent()` can be received in the format `@page-updated.window`. This is an Alpine.js feature.
+https://alpinejs.dev/essentials/events#listening-for-events-on-window
+
+```php
+<div x-data @page-updated.window="">
+    @foreach ($posts as $post)
+        ...
+    @endforeach
+
+    {{ $posts->links() }}
+</div>
+```
+
+`x-data` is also required (easy to forget).
+
+Finally, scroll when the event is received.
+
+```php
+<div x-data @page-updated.window="$el.scrollIntoView({behavior: 'smooth'})">
+    @foreach ($posts as $post)
+        ...
+    @endforeach
+
+    {{ $posts->links() }}
+</div>
+```
+
+`$el.scrollIntoView({behavior: 'smooth'})`
+
+`$el` refers to the element itself, in this case, the div. This is an Alpine.js feature.
+It should be the same with something like `<div x-data @page-updated.window="document.querySelector('#test').scrollIntoView({behavior: 'smooth'})" id="test">`.
+
+`scrollIntoView` scrolls to the position of this element. This is standard JavaScript.
+However, `{behavior: 'smooth'}` is not supported in Safari. This means it's also not supported in Chrome on iOS. If you want to support it, use a polyfill.
+https://github.com/iamdustan/smoothscroll
+
+In `resources/js/app.js` or similar:
+```js
+require('./bootstrap');
+
+import Alpine from 'alpinejs';
+
+window.Alpine = Alpine;
+
+Alpine.start();
+
+import smoothscroll from 'smoothscroll-polyfill';
+
+smoothscroll.polyfill();
+```
+**(Update: Safari 15.4 now supports this, so the polyfill is no longer needed.)**
+
+You can scroll to any position by changing where you write `@page-updated.window`.
+
+This allows you to achieve "scroll to top when changing pages in Livewire pagination."
+
+## Back to top
+Personally, I don't use it much, but a "Back to top" button can also be implemented with the content of this article.
+
+## Addendum
+Livewire 3.0.6 and later automatically scroll, so you can ignore this entire article.

--- a/en/livewire-paginators-with-octane.md
+++ b/en/livewire-paginators-with-octane.md
@@ -1,0 +1,237 @@
+# Difficulty Using Laravel and Livewire Pagination Together in an Octane Environment
+
+---
+
+## Versions
+- Laravel 9.x
+- Livewire 2.x
+- Octane 1.x ([Vapor+Octane](https://docs.vapor.build/1.0/projects/environments.html#octane))
+- PHP 8.1
+
+## WithPagination
+Livewire's pagination doesn't seem to do anything unusual when used normally, but looking closely, `initializeWithPagination()` changes it to Livewire's unique behavior.
+
+https://github.com/livewire/livewire/blob/master/src/WithPagination.php
+
+```php
+        if (class_exists(CursorPaginator::class)) {
+            CursorPaginator::currentCursorResolver(function ($pageName){
+                if (! isset($this->paginators[$pageName])) {
+                    $this->paginators[$pageName] = request()->query($pageName, '');
+                }
+                return Cursor::fromEncoded($this->paginators[$pageName]);
+            });
+        }
+
+        Paginator::currentPageResolver(function ($pageName) {
+            if (! isset($this->paginators[$pageName])) {
+                $this->paginators[$pageName] = request()->query($pageName, 1);
+            }
+
+            return (int) $this->paginators[$pageName];
+        });
+
+        Paginator::defaultView($this->paginationView());
+        Paginator::defaultSimpleView($this->paginationSimpleView());
+```
+
+`Paginator::currentPageResolver` and `Paginator::defaultView` modify static properties here.
+
+https://github.com/laravel/framework/blob/9.x/src/Illuminate/Pagination/AbstractPaginator.php
+
+```php
+    /**
+     * The current page resolver callback.
+     *
+     * @var \Closure
+     */
+    protected static $currentPageResolver;
+
+    /**
+     * Set the current page resolver callback.
+     *
+     * @param  \Closure  $resolver
+     * @return void
+     */
+    public static function currentPageResolver(Closure $resolver)
+    {
+        static::$currentPageResolver = $resolver;
+    }
+```
+
+The fact that they are static properties is what causes problems with Octane.
+
+1. Livewire's pagination is displayed first. At this time, the static properties are overwritten. With Octane, they remain overwritten for the next request.
+2. Even if Laravel's normal pagination is displayed, it will be displayed based on the overwritten static properties, resulting in an error. Without Octane, it's reset every time, so there's no impact.
+
+## Trial and Error
+
+### If the view is different
+You can specify it at display time, but specifying it everywhere is cumbersome.
+```php
+{{ $posts->links('pagination::tailwind') }}
+```
+
+It seems unlikely that static properties can be overwritten again when displaying Laravel pagination in `AppServiceProvider::boot()`.
+```php
+Paginator::defaultView('pagination::tailwind');
+Paginator::defaultSimpleView('pagination::simple-tailwind');
+```
+
+Specify the view when displaying with `links()`.
+Since `defaultView()` is the default, if specified, the default will not be used. (The default at this point is the view file overwritten by Livewire).
+
+### Resetting the Resolver
+It seems possible to reset with `PaginationState::resolveUsing()`.
+
+https://github.com/laravel/framework/blob/9.x/src/Illuminate/Pagination/PaginationState.php
+
+It's used internally in Laravel here:
+```php
+    /**
+     * Register the service provider.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        PaginationState::resolveUsing($this->app);
+    }
+```
+
+https://github.com/laravel/framework/blob/9.x/src/Illuminate/Pagination/PaginationServiceProvider.php
+
+I thought I could just write it in `AppServiceProvider` similarly, but it didn't solve the problem.
+Like the view, reset it in the controller every time it's displayed.
+
+```php
+use Illuminate\Pagination\PaginationState;
+
+//...
+
+    public function index(Request $request)
+    {
+        PaginationState::resolveUsing(app());
+
+        $posts = Post::latest()->paginate();
+
+        return view('post.index')->with(compact('posts'));
+    }
+```
+
+Aside from the hassle, Laravel's pagination was fixed, but now Livewire's pagination started throwing errors.
+
+## Reset with Octane's Listener (Best Solution)
+Setting a Listener in `config/octane.php` to initialize with each request seems to be the current solution.
+
+https://github.com/laravel/octane/blob/1.x/config/octane.php
+
+```php
+        RequestReceived::class => [
+            ...Octane::prepareApplicationForNextOperation(),
+            ...Octane::prepareApplicationForNextRequest(),
+            //
+        ],
+```
+
+Following the flow, various initialization processes are performed when the `RequestReceived` event occurs.
+
+`prepareApplicationForNextOperation()` includes `PrepareLivewireForNextOperation`.
+
+https://github.com/laravel/octane/blob/1.x/src/Concerns/ProvidesDefaultConfigurationOptions.php
+
+`PrepareLivewireForNextOperation` calls Livewire's `flushState()`.
+
+https://github.com/laravel/octane/blob/1.x/src/Listeners/PrepareLivewireForNextOperation.php
+
+Since `flushState()` doesn't handle pagination, you need to do it yourself.
+
+https://github.com/livewire/livewire/blob/e9f178bc4f1e671e562f9d2251aa07702b2c2260/src/LivewireManager.php#L460
+
+First, create a Listener.
+
+```
+sail art make:listener FlushPagination
+```
+or
+```
+php artisan make:listener FlushPagination
+```
+
+FlushPagination.php is as follows:
+
+```php
+<?php
+
+namespace App\Listeners;
+
+use Illuminate\Pagination\PaginationState;
+use Illuminate\Pagination\Paginator;
+
+class FlushPagination
+{
+    /**
+     * Create the event listener.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Handle the event.
+     *
+     * @param  object  $event
+     * @return void
+     */
+    public function handle($event)
+    {
+        Paginator::useTailwind();
+        PaginationState::resolveUsing($event->sandbox);
+    }
+}
+```
+
+Add to `config/octane.php`.
+
+```php
+        RequestReceived::class => [
+            ...Octane::prepareApplicationForNextOperation(),
+            ...Octane::prepareApplicationForNextRequest(),
+            //
+            \App\Listeners\FlushPagination::class,
+        ],
+```
+
+`useTailwind()` is the same as below. If not using Tailwind, change as you like.
+
+```php
+Paginator::defaultView('pagination::tailwind');
+Paginator::defaultSimpleView('pagination::simple-tailwind');
+```
+
+`$event->sandbox` and `app()` should be the same.
+
+Now, specifying the view every time is unnecessary.
+```php
+{{ $posts->links() }}
+```
+
+`PaginationState::resolveUsing()` in ServiceProviders or controllers is also unnecessary.
+
+No errors occur when navigating between pages using Laravel's pagination and Livewire's pagination.
+
+There are no problems with normal use. It's impossible to confirm if other problems will arise without using it for a while.
+
+## With Octane v1.2.10
+https://github.com/laravel/octane/releases/tag/v1.2.10
+`PaginationState::resolveUsing($event->sandbox);` has also been enabled on the Octane side, so it's no longer needed in `FlushPagination`.
+```php
+    public function handle($event)
+    {
+        Paginator::useTailwind();
+    }
+}
+```

--- a/en/livewire-volt.md
+++ b/en/livewire-volt.md
@@ -1,0 +1,607 @@
+# Comparison of Standard Livewire Usage and Volt
+
+---
+
+## Versions
+- Laravel 10.x
+- Livewire 3.2.6 https://github.com/livewire/livewire
+- Volt 1.6.0 https://github.com/livewire/volt
+
+Information as of December 2023, as features are still being added recently.
+
+## Documentation
+https://livewire.laravel.com/docs/volt
+
+## Three Styles
+You can use all three styles simultaneously within a single Laravel project. You can use Volt functional for simple pages and the standard way for complex pages. It's also common to initially create something with Volt functional and then refactor it to the standard way as it becomes more complex.
+
+### Livewire Standard
+The usual way of using Livewire with separate PHP and Blade files.
+Implementation example: Jetstream's Livewire stack.
+
+Understanding the standard way is essential before using Volt.
+This article summarizes how to write features from the standard way using Volt.
+
+### Volt functional
+A new way to use Livewire with only Blade files. In Vue.js terms, a single-file Livewire component.
+Implementation example: Breeze's livewire-functional stack. https://github.com/laravel/breeze/tree/1.x/stubs/livewire-functional/resources/views/livewire
+
+```php
+<?php
+
+use function Livewire\Volt\{state};
+
+state(['count' => 0]);
+
+$increment = fn () => $this->count++;
+
+?>
+
+<div>
+    <h1>{{ $count }}</h1>
+    <button wire:click="increment">+</button>
+</div>
+```
+
+It's similar to Laravel Folio and was announced together, but it's unrelated to Folio.
+
+### Volt Class-based
+Volt adapted to a style using anonymous classes, similar to the standard way.
+Implementation example: Breeze's livewire stack. https://github.com/laravel/breeze/tree/1.x/stubs/livewire/resources/views/livewire
+
+```php
+<?php
+
+use Livewire\Volt\Component;
+
+new class extends Component {
+    public $count = 0;
+
+    public function increment()
+    {
+        $this->count++;
+    }
+} ?>
+
+<div>
+    <h1>{{ $count }}</h1>
+    <button wire:click="increment">+</button>
+</div>
+```
+It feels like adding this just made things more complicated. Laravel allowing multiple ways of doing things is already a source of confusion, and adding more options is clearly bad.
+
+## Component Creation Command
+
+### Livewire Standard
+```
+php artisan make:livewire counter
+```
+
+### Volt functional
+```
+php artisan make:volt counter
+```
+Since it's a single file, for subsequent components, it's more practical to duplicate an existing component and modify it rather than using the command.
+
+### Volt Class-based
+Same as functional.
+
+## File Locations
+
+### Livewire Standard
+- PHP files in `app/Livewire/`
+- Blade files in `resources/views/livewire`
+
+### Volt functional
+Only Blade files in `resources/views/livewire`.
+
+Blade files placed in `resources/views/pages` can also be used. This likely anticipates use cases like creating a page for Folio and then wanting to add functionality, converting it to Volt. It's unclear if Folio's file-based routing and Volt can be used simultaneously as I haven't tested it.
+
+### Volt Class-based
+Same as functional.
+
+## Properties and mount
+
+### Livewire Standard
+```php
+<?php
+
+namespace App\Livewire;
+
+use App\Models\Post;
+use Livewire\Component;
+
+class PostIndex extends Component
+{
+    public $posts;
+
+    public function mount()
+    {
+        $this->posts = Post::all();
+    }
+}
+```
+
+### Volt functional
+```php
+<?php
+use App\Models\Post;
+use function Livewire\Volt\state;
+use function Livewire\Volt\mount;
+
+state('posts');
+
+mount(function () {
+    $this->posts = Post::all();
+});
+?>
+<div></div>
+```
+
+### Volt Class-based
+```php
+<?php
+
+use App\Models\Post;
+use Livewire\Volt\Component;
+
+new class extends Component {
+    public $posts;
+
+    public function mount()
+    {
+        $this->posts = Post::all();
+    }
+}
+?>
+<div></div>
+```
+
+## Actions
+
+### Livewire Standard
+```php
+namespace App\Livewire;
+
+use Livewire\Component;
+use App\Models\Post;
+
+class CreatePost extends Component
+{
+    public $title = '';
+
+    public $content = '';
+
+    public function save()
+    {
+        Post::create([
+            'title' => $this->title,
+            'content' => $this->content,
+        ]);
+
+        return redirect()->to('/posts');
+    }
+}
+```
+
+```php
+<form wire:submit="save">
+    <input type="text" wire:model="title">
+
+    <textarea wire:model="content"></textarea>
+
+    <button type="submit">Save</button>
+</form>
+```
+
+### Volt functional
+```php
+<?php
+
+use App\Models\Post;
+use function Livewire\Volt\state;
+
+state(['title', 'content']);
+
+$save = function () {
+    Post::create([
+        'title' => $this->title,
+        'content' => $this->content,
+    ]);
+
+    return redirect()->to('/posts');
+};
+?>
+
+<div>
+    <form wire:submit="save">
+        <input type="text" wire:model="title">
+
+        <textarea wire:model="content"></textarea>
+
+        <button type="submit">Save</button>
+    </form>
+</div>
+```
+
+### Volt Class-based
+Almost the same as standard, so omitted hereafter.
+
+## Validation
+### Livewire Standard
+Specify with the `Validate` attribute.
+
+```php
+use Livewire\Attributes\Validate;
+use Livewire\Component;
+use App\Models\Post;
+
+class CreatePost extends Component
+{
+    #[Validate('required|min:3')]
+    public $title = '';
+
+    #[Validate('required|min:3')]
+    public $content = '';
+}
+```
+
+### Volt functional
+Specify with `rules()`.
+
+```php
+<?php
+
+use function Livewire\Volt\{rules};
+
+rules(['name' => 'required|min:6', 'email' => 'required|email']);
+
+$submit = function () {
+    $this->validate();
+
+    // ...
+};
+
+?>
+
+<form wire:submit.prevent="submit">
+    //
+</form>
+```
+
+## Computed Properties
+### Livewire Standard
+```php
+use Livewire\Attributes\Computed;
+use Livewire\Component;
+use App\Models\User;
+
+class ShowUser extends Component
+{
+    #[Computed]
+    public function count()
+    {
+        return User::count();
+    }
+```
+
+### Volt functional
+```php
+<?php
+
+use App\Models\User;
+use function Livewire\Volt\{computed};
+
+$count = computed(function () {
+    return User::count();
+});
+
+?>
+
+<div>
+    {{ $this->count }}
+</div>
+```
+
+## Pagination
+### Livewire Standard
+Easy to forget to add `WithPagination`.
+
+```php
+<?php
+
+namespace App\Livewire;
+
+use Livewire\WithPagination;
+use Livewire\Component;
+use App\Models\Post;
+
+class ShowPosts extends Component
+{
+    use WithPagination;
+
+    public function render()
+    {
+        return view('show-posts', [
+            'posts' => Post::paginate(10),
+        ]);
+    }
+}
+```
+
+### Volt functional
+```php
+<?php
+
+use function Livewire\Volt\{with, usesPagination};
+
+usesPagination();
+
+with(fn () => ['posts' => Post::paginate(10)]);
+
+?>
+
+<div>
+    @foreach ($posts as $post)
+        //
+    @endforeach
+
+    {{ $posts->links() }}
+</div>
+```
+
+## File Uploads
+### Livewire Standard
+```php
+<?php
+
+namespace App\Livewire;
+
+use Livewire\Component;
+use Livewire\WithFileUploads;
+use Livewire\Attributes\Validate;
+
+class UploadPhoto extends Component
+{
+    use WithFileUploads;
+
+    #[Validate('image|max:1024')]
+    public $photo;
+
+    public function save()
+    {
+        $this->photo->store('photos');
+    }
+}
+```
+
+### Volt functional
+```php
+use function Livewire\Volt\{state, usesFileUploads};
+
+usesFileUploads();
+
+state(['photo']);
+
+$save = function () {
+    $this->validate([
+        'photo' => 'image|max:1024',
+    ]);
+
+    $this->photo->store('photos');
+};
+```
+
+## Full-page component Layout Specification
+
+### Livewire Standard
+Specify in `render()` or with the `Layout` attribute on the class. Layouts are generally fixed, so specifying with an attribute should be fine.
+
+```php
+<?php
+
+namespace App\Livewire;
+
+use Livewire\Attributes\Layout;
+use Livewire\Component;
+
+class CreatePost extends Component
+{
+    // ...
+
+    #[Layout('layouts.app')]
+    public function render()
+    {
+        return view('livewire.create-post');
+    }
+}
+```
+
+```php
+<?php
+
+namespace App\Livewire;
+
+use Livewire\Attributes\Layout;
+use Livewire\Component;
+
+#[Layout('layouts.app')]
+class CreatePost extends Component
+{
+    // ...
+}
+```
+
+### Volt functional
+Specify with `layout()`.
+
+```php
+use function Livewire\Volt\{layout, state};
+
+state('users');
+
+layout('components.layouts.admin');
+```
+
+## Full-page component title Specification
+Only `title` has special treatment.
+
+First, prepare `$title` in the layout file.
+```php
+<title>{{ $title ?? config('app.name') }}</title>
+```
+
+### Livewire Standard
+```php
+<?php
+
+namespace App\Livewire;
+
+use Livewire\Attributes\Layout;
+use Livewire\Component;
+
+class Post extends Component
+{
+    public $post;
+
+    public function render()
+    {
+        return view('livewire.post-show')
+            ->title($this->post->title);
+    }
+}
+```
+Incidentally, although removed from the Livewire 3 documentation, there is also `layoutData()` to pass data other than title to the layout.
+```php
+    public function render()
+    {
+        return view('livewire.post-show')
+            ->layoutData(['foo' => 'bar']);
+    }
+```
+
+There's also a method to specify with the `Title` attribute, but it can only be used for fixed titles, so it's rarely used.
+
+```php
+use Livewire\Attributes\Title;
+use Livewire\Component;
+
+class CreatePost extends Component
+{
+    // ...
+
+    #[Title('Create Post')]
+    public function render()
+    {
+        return view('livewire.create-post');
+    }
+}
+```
+
+### Volt functional
+
+```php
+use function Livewire\Volt\{state, title};
+
+state('post');
+
+title(fn() => $this->post->title);
+```
+
+A fixed title like `title('Post');` is also possible, but this will also rarely be used.
+
+### Volt Class-based
+This one is special and specified with `rendering()`.
+```php
+<?php
+
+use Illuminate\View\View;
+use Livewire\Volt\Component;
+
+new class extends Component {
+    public function rendering(View $view): void
+    {
+        $view->title('Create Post');
+
+        // ...
+    }
+
+    // ...
+```
+
+## Full-page component Routing
+### Livewire Standard
+Specify the PHP file.
+```php
+use App\Livewire\CreatePost;
+
+Route::get('/posts/create', CreatePost::class)->name('post.create');
+```
+
+### Volt functional
+Specify the Blade file. The return value of `Volt::route()` is a Route, so specifying `name` etc. is possible as usual.
+```php
+use Livewire\Volt\Volt;
+
+Volt::route('/users', 'user-index')->name('user.index');
+```
+
+## URL Query Parameters
+
+### Livewire Standard
+```php
+<?php
+
+namespace App\Livewire;
+
+use Livewire\Attributes\Url;
+use Livewire\Component;
+
+class ShowUsers extends Component
+{
+    #[Url]
+    public $search = '';
+```
+
+### Volt functional
+```php
+<?php
+
+use function Livewire\Volt\{state};
+
+state(['search'])->url();
+```
+
+## Event Listeners
+### Livewire Standard
+```php
+use Livewire\Component;
+use Livewire\Attributes\On;
+
+class Dashboard extends Component
+{
+    #[On('post-created')]
+    public function updatePostList($title)
+    {
+        // ...
+    }
+}
+```
+### Volt functional
+```php
+use function Livewire\Volt\{on};
+
+on(['post-created' => function () {
+    //
+}]);
+```
+
+## That's all
+I've summarized the features you'll likely use often. For anything more, please refer to the documentation.
+
+Article for Advent Calendar.
+https://qiita.com/advent-calendar/2023/laravel
+
+This isn't intended for long-form content, but since I haven't been writing externally lately, I'm writing it here.
+I'm also keeping a copy on GitHub in case the domain is abandoned.
+https://github.com/pop-culture-studio/articles/blob/main/livewire-volt.md

--- a/en/vercel-severless-functions-api-json.md
+++ b/en/vercel-severless-functions-api-json.md
@@ -1,0 +1,156 @@
+# Vercel Serverless Function to Return JSON from an External Web API (Node.js/TypeScript/Golang/Ruby/Python versions)
+
+---
+
+This article does not explain serverless functions themselves.
+
+https://vercel.com/docs/concepts/functions/serverless-functions
+
+## Target Audience
+- You are running a static HTML-only site on Vercel.
+- You want to use an external API that cannot be used from front-end JavaScript.
+- You are not using a front-end framework. If you are using Next.js or similar, you should use the framework's features.
+
+## Many APIs Cannot Be Used From Front-end JavaScript
+There are many instances where people who only know front-end development have a major misunderstanding: it's not a given that Web APIs can be used from the front-end.
+By default, cross-origin external APIs cannot be used from front-end JS.
+Recognize that they are only specially permitted by CORS.
+
+This is essential prerequisite knowledge.
+
+The solution is "fetch it on the server-side."
+Prepare an API on the "same origin" or "CORS-allowed cross-origin" that returns the JSON fetched on the server-side, and use this API from the front-end.
+
+With Vercel serverless functions, you can prepare a small amount of server-side processing within the same origin.
+(You can also prepare it in a completely different location other than Vercel, or even just place a JSON file on S3. There are various methods.)
+
+## Node.js
+Configure Vercel to use Node.js 18.x or higher, as native `fetch()` is only available in version 18 and above.
+
+`/api/node.js`
+```javascript
+const url = 'https://...';
+
+export default async function (req, response) {
+    const res = await fetch(url);
+
+    const data = await res.json();
+
+    response.setHeader('Content-Type', 'application/json; charset=utf-8').send(data);
+}
+```
+
+## TypeScript
+- Node.js 18.x or higher
+- Install `@vercel/node` with `npm install @vercel/node --save-dev`.
+
+`/api/typescript.ts`
+```typescript
+import type {VercelRequest, VercelResponse} from '@vercel/node';
+
+const url: string = 'https://...';
+
+export default async function (req: VercelRequest, response: VercelResponse) {
+    const res: Response = await fetch(url);
+
+    const data: any = await res.json(); // Changed 'string' to 'any' for broader compatibility
+
+    response.setHeader('Content-Type', 'application/json; charset=utf-8').send(data);
+}
+```
+There's little point in using TypeScript here, so it's almost the same as Node.js.
+
+## Golang
+If you're just returning it as is, there's no need to convert the JSON to a struct.
+
+`gopher.go` (assuming the filename corresponds to the API endpoint, e.g., `/api/gopher`)
+```go
+package handler // The package name must be 'handler' for Vercel
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+)
+
+const url = "https://..."
+
+func Handler(w http.ResponseWriter, r *http.Request) { // The function must be named Handler
+	res, err := http.Get(url)
+	if err != nil {
+		log.Fatal(err) // Consider http.Error for better error handling in production
+	}
+	defer res.Body.Close()
+
+	jsonBody, err := io.ReadAll(res.Body) // Renamed 'json' to 'jsonBody' to avoid conflict
+
+	if err != nil {
+		log.Fatal(err) // Consider http.Error
+	}
+
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+
+	fmt.Fprintln(w, string(jsonBody))
+}
+```
+
+## Ruby
+
+`/api/ruby.rb`
+```ruby
+require 'net/http'
+require 'uri'
+require 'json' # Required for parsing if the external API returns non-string JSON
+
+Handler = Proc.new do |req, res|
+  api_url = 'https://...' # Renamed 'url' to 'api_url' to avoid conflict with Vercel's 'url' property on req
+
+  uri = URI.parse(api_url)
+  response_body = Net::HTTP.get(uri)
+
+  res.status = 200
+  res['Content-Type'] = 'application/json; charset=utf-8'
+  res.body = response_body # Assuming the API returns a JSON string
+end
+```
+
+If you were creating serverless functions in multiple languages, you might encounter a file size error. Ruby alone should be fine, but complex usage involving many installations might hit this limit.
+```
+Error: The Serverless Function "api/ruby" is 202.13mb which exceeds the maximum size limit of 50mb. Learn More: https://vercel.link/serverless-function-size
+```
+
+## Python
+
+`/api/python.py`
+```python
+from http.server import BaseHTTPRequestHandler
+import urllib.request
+import json # For potential future use if you need to manipulate the JSON
+
+class handler(BaseHTTPRequestHandler):
+
+    def do_GET(self):
+        api_url = 'https://...' # Renamed 'url'
+
+        req = urllib.request.Request(api_url)
+        with urllib.request.urlopen(req) as res:
+            body = res.read()
+
+        self.send_response(200)
+        self.send_header('Content-type','application/json; charset=utf-8')
+        self.end_headers()
+        self.wfile.write(body)
+        return
+```
+
+## How to Use
+Create a file in the `/api/` directory and copy-paste the code.
+Use it from the front-end with the URL determined by the filename.
+
+Example: Create `/api/example.js`, copy-paste the code, and use it from the front-end with `fetch('/api/example')`.
+
+Specify the external API in the `url` variable. If the API specification uses methods other than GET (though unlikely), modifications will be necessary.
+If an API key is required, get it from environment variables.
+
+It's easy with languages officially supported by Vercel, with no extra hassle.


### PR DESCRIPTION
This commit includes the translation of all Japanese Markdown files in the repository to English.

Here's what I did:
- I created a new directory `/en/` to store the translated files.
- I translated each of the following Markdown files from Japanese to English and saved them in the `/en/` directory:
    - laravel-installation-mac.md
    - laravel-installation-windows.md
    - laravel-is-not-mvc.md
    - laravel-recaptcha.md
    - laravel-taboo.md
    - laravel-unless.md
    - laravel-vite-plugin.md
    - laravel11-application-builder.md
    - livewire-pagination.md
    - livewire-paginators-with-octane.md
    - livewire-volt.md
    - vercel-severless-functions-api-json.md